### PR TITLE
require purchase interval selection when adding item to list

### DIFF
--- a/src/components/AddItemForm.js
+++ b/src/components/AddItemForm.js
@@ -37,15 +37,33 @@ function AddItemForm() {
       </label>
       <div className="nextPurchaseRadioGroup">
         <label>
-          <input id="soon" type="radio" value="7" name="nextPurchase" />
+          <input
+            id="soon"
+            type="radio"
+            value="7"
+            name="nextPurchase"
+            required
+          />
           Soon
         </label>
         <label>
-          <input id="kindOfSoon" type="radio" value="14" name="nextPurchase" />
+          <input
+            id="kindOfSoon"
+            type="radio"
+            value="14"
+            name="nextPurchase"
+            required
+          />
           Kind of Soon
         </label>
         <label>
-          <input id="notSoon" type="radio" value="30" name="nextPurchase" />
+          <input
+            id="notSoon"
+            type="radio"
+            value="30"
+            name="nextPurchase"
+            required
+          />
           Not Soon
         </label>
         <label>


### PR DESCRIPTION
## Description

This PR adds client side form validation which requires a `purchaseInterval` selection on the `/additem` form.

## Related Issue
Closes #28 

## Acceptance Criteria

- [x] Only submit new list items if a `purchaseInterval` selection is made
- [x] Prompt the user to make a selection if left blank

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before


![](https://user-images.githubusercontent.com/3861088/139186822-429f5155-1c97-43c9-8f47-a0acd6266ee3.gif)


### After

![Screen Recording 2021-10-28 at 09 05 11 AM](https://user-images.githubusercontent.com/23363171/139284723-7de29032-6f5b-47e0-bfcf-aaf321db3635.gif)



## Testing Steps / QA Criteria

1. Check out this branch with `git checkout mh-make-purchase-interval--selection-required`
2. Start the server with `npm run start`
3. Open the app at `http://localhost:3000/`
4. Click `Create new list`
5. Add a new item without a `purchaseInterval` selection to see the prompt to make a selection
6. Select a `purchaseInterval` and re-try adding the item
7. Success 💯 