### PR TITLE
jr-fc-estimate-next-purchase-date

### DIFF
--- a/src/components/AddItemForm.js
+++ b/src/components/AddItemForm.js
@@ -57,7 +57,7 @@ function AddItemForm() {
       purchaseInterval: purchaseInterval,
       userToken: userToken,
       lastPurchased: lastPurchased,
-      nextPurchase: null,
+      daysUntilNextPurchase: null,
       numberOfPurchases: 0,
     });
   };

--- a/src/components/AddItemForm.js
+++ b/src/components/AddItemForm.js
@@ -59,6 +59,9 @@ function AddItemForm() {
       lastPurchased: lastPurchased,
       daysUntilNextPurchase: null,
       numberOfPurchases: 0,
+      backupLastPurchased: lastPurchased,
+      backupDaysUntilNextPurchase: null,
+      backupNumberOfPurchases: 0,
     });
   };
 

--- a/src/components/AddItemForm.js
+++ b/src/components/AddItemForm.js
@@ -57,6 +57,8 @@ function AddItemForm() {
       purchaseInterval: purchaseInterval,
       userToken: userToken,
       lastPurchased: lastPurchased,
+      nextPurchase: null,
+      numberOfPurchases: 0,
     });
   };
 

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -7,8 +7,7 @@ import './Item.css';
 function Item({ item, userToken }) {
   const [checked, setChecked] = useState(false);
   const [daysSincePurchased, setDaysSincePurchased] = useState(0);
-  const [itemBackup, setItemBackup] = useState(item);
-  console.log('itemBackup', itemBackup);
+  const [itemBackup] = useState(item);
 
   useEffect(() => {
     if (item.lastPurchased) {
@@ -21,11 +20,12 @@ function Item({ item, userToken }) {
   }, [item]);
 
   useEffect(() => {
-    if (daysSincePurchased > 1 || daysSincePurchased === 0) {
-      setChecked(false);
-    } else if (daysSincePurchased < 1) {
+    if (daysSincePurchased < 1 && daysSincePurchased !== 0) {
       setChecked(true);
+      return;
     }
+
+    setChecked(false);
   }, [daysSincePurchased, checked]);
 
   const handleCheckboxChange = () => {
@@ -35,7 +35,6 @@ function Item({ item, userToken }) {
   const updateLastPurchased = async (event) => {
     const docRef = doc(db, 'users', `${userToken}`, 'list', item.id);
     if (event.target.checked) {
-      // setItemBackup(item)
       updateDoc(docRef, {
         lastPurchased: serverTimestamp(),
         numberOfPurchases: item.numberOfPurchases + 1,

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { updateDoc, serverTimestamp, doc } from 'firebase/firestore';
+import { updateDoc, serverTimestamp, doc, getDoc } from 'firebase/firestore';
 import { db } from '../lib/firebase';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import './Item.css';
 
 function Item({ item, userToken }) {
@@ -32,12 +33,19 @@ function Item({ item, userToken }) {
   const updateLastPurchased = async (event) => {
     const docRef = doc(db, 'users', `${userToken}`, 'list', item.id);
     if (event.target.checked) {
-      await updateDoc(docRef, {
+      updateDoc(docRef, {
         lastPurchased: serverTimestamp(),
+        numberOfPurchases: item.numberOfPurchases + 1,
+        nextPurchase: calculateEstimate(
+          item.purchaseInterval,
+          daysSincePurchased,
+          item.numberOfPurchases,
+        ),
       });
     } else {
-      await updateDoc(docRef, {
+      updateDoc(docRef, {
         lastPurchased: null,
+        numberOfPurchases: item.numberOfPurchases - 1,
       });
       setDaysSincePurchased(null);
     }


### PR DESCRIPTION
## Description

This code adds daysUntilNextPurchase into the DB and calculates this number when you first purchase an item and click the checkbox. 

We also have a itemBackup state to store the previous value as version control. If you change your mind or accidentally clicked the checkbox, you can click it again which will now uncheck and then revert the data in the DB back to the previous values. 

## Related Issue

closes #10 

## Acceptance Criteria

When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |

|  ✓ | :sparkles: New feature     |

## Updates

### Before

![](https://cdn.zappy.app/c7d38bed9d3ccd25f2183e4379d3709c.png)


### After

![](https://cdn.zappy.app/24f8c1d84db3a9b11dd22ba363da89bb.png)


## Testing Steps / QA Criteria

- ```git checkout jr-fc-estimate-next-purchase-date```
- ```npm start```
- Create a new list and add a few items
- Open Firestore and open items you added
- when you click the purchased checkbox you will now see the daysUntilNextPurchase recorded with the calculateEstimate results
- You can uncheck if you change your mind and see the values are reverted back to the previous state as a limited version control
 