### PR TITLE
add focus trap library, refocus input on delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@the-collab-lab/shopping-list-utils": "^1.0.3",
         "firebase": "^9.1.1",
+        "focus-trap-react": "^8.8.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "react-router-dom": "^5.3.0",
@@ -9622,6 +9623,27 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "node_modules/focus-trap": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.7.1.tgz",
+      "integrity": "sha512-a6czHbT9twVpy2RpkWQA9vIgwQgB9Nx1PIxNNUxQT4nugG/3QibwxO+tWTh9i+zSY2SFiX4pnYhTaFaQF/6ZAg==",
+      "dependencies": {
+        "tabbable": "^5.2.1"
+      }
+    },
+    "node_modules/focus-trap-react": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.8.2.tgz",
+      "integrity": "sha512-YgacIMxeAOytHOEbzBWL7+itBkn4ARMwQhtt6hYVHqHzPUPhmfEyKJ/nqsyMerzOK1DzlDv8Q8phRAY8vpa0rA==",
+      "dependencies": {
+        "focus-trap": "^6.7.1"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.7.2",
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
@@ -18891,6 +18913,11 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "node_modules/tabbable": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz",
+      "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
     },
     "node_modules/table": {
       "version": "6.7.2",
@@ -28904,6 +28931,22 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focus-trap": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.7.1.tgz",
+      "integrity": "sha512-a6czHbT9twVpy2RpkWQA9vIgwQgB9Nx1PIxNNUxQT4nugG/3QibwxO+tWTh9i+zSY2SFiX4pnYhTaFaQF/6ZAg==",
+      "requires": {
+        "tabbable": "^5.2.1"
+      }
+    },
+    "focus-trap-react": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.8.2.tgz",
+      "integrity": "sha512-YgacIMxeAOytHOEbzBWL7+itBkn4ARMwQhtt6hYVHqHzPUPhmfEyKJ/nqsyMerzOK1DzlDv8Q8phRAY8vpa0rA==",
+      "requires": {
+        "focus-trap": "^6.7.1"
+      }
+    },
     "follow-redirects": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
@@ -36179,6 +36222,11 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "tabbable": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz",
+      "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
     },
     "table": {
       "version": "6.7.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@the-collab-lab/shopping-list-utils": "^1.0.3",
     "firebase": "^9.1.1",
+    "focus-trap-react": "^8.8.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.3.0",

--- a/src/components/DeleteItemButton.js
+++ b/src/components/DeleteItemButton.js
@@ -6,18 +6,18 @@ import Modal from './Modal';
 function DeleteItemButton(item) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleDelete = async ({ userToken, item, onClose }) => {
+  const handleDelete = async ({ userToken, item, focusOnInput }) => {
     setIsOpen(false);
     const docRef = doc(db, 'users', userToken, 'list', item);
     await deleteDoc(docRef);
+    focusOnInput();
   };
 
   return (
     <div>
       <button onClick={() => setIsOpen(true)}>Delete</button>
-
       <Modal open={isOpen}>
-        <p id="dialog-description">Are you sure you want to delete?</p>
+        <p>Are you sure you want to delete?</p>
         <button onClick={() => handleDelete(item)}>Yes</button>
         <button onClick={() => setIsOpen(false)}>Cancel</button>
       </Modal>

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -4,7 +4,7 @@ import { db } from '../lib/firebase';
 import './Item.css';
 import DeleteItemButton from './DeleteItemButton';
 
-function Item({ item, userToken }) {
+function Item({ item, userToken, focusOnInput }) {
   const [checked, setChecked] = useState(false);
   const [daysSincePurchased, setDaysSincePurchased] = useState();
 
@@ -47,9 +47,9 @@ function Item({ item, userToken }) {
   return (
     <li className="item">
       <form>
-        <label htmlFor="itemPurchased">Purchased</label>
+        <label htmlFor={`itemPurchased-${item.id}`}>Purchased</label>
         <input
-          id="itemPurchased"
+          id={`itemPurchased-${item.id}`}
           type="checkbox"
           checked={checked}
           name="itemPurchased"
@@ -58,7 +58,11 @@ function Item({ item, userToken }) {
         />
       </form>
       <p className="item-name">{item.itemName}</p>
-      <DeleteItemButton item={item.id} userToken={userToken} />
+      <DeleteItemButton
+        item={item.id}
+        userToken={userToken}
+        focusOnInput={focusOnInput}
+      />
     </li>
   );
 }

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDom from 'react-dom';
+import FocusTrap from 'focus-trap-react';
 
 const modalStyles = {
   position: 'fixed',
@@ -28,10 +29,12 @@ export default function Modal({ open, children }) {
   if (!open) return null;
 
   return ReactDom.createPortal(
-    <div role="alert" aria-describedby="dialog-description">
-      <div style={overlayStyles} />
-      <div style={modalStyles}>{children}</div>
-    </div>,
+    <FocusTrap>
+      <div role="dialog">
+        <div style={overlayStyles} />
+        <div style={modalStyles}>{children}</div>
+      </div>
+    </FocusTrap>,
     document.getElementById('portal'),
   );
 }

--- a/src/components/SearchList.js
+++ b/src/components/SearchList.js
@@ -22,6 +22,10 @@ export default function SearchList({ listItems, userToken }) {
     return item.itemNameNormalize.includes(normalizedSearch);
   });
 
+  const focusOnInput = () => {
+    searchInputRef.current.focus();
+  };
+
   return (
     <div>
       Filter Items:
@@ -39,7 +43,14 @@ export default function SearchList({ listItems, userToken }) {
       )}
       <ul className="items-list">
         {filteredList.map((item) => {
-          return <Item key={item.id} item={item} userToken={userToken} />;
+          return (
+            <Item
+              key={item.id}
+              item={item}
+              userToken={userToken}
+              focusOnInput={focusOnInput}
+            />
+          );
         })}
       </ul>
     </div>


### PR DESCRIPTION
I added the `focus-trap-react` [package](https://github.com/focus-trap/focus-trap-react) to use for the modal and created a function that places focus on the search input after an item is deleted so that the user is not dropped out of the app flow.

Changes in action with a screen reader:

https://user-images.githubusercontent.com/19564687/141665518-70662713-722a-4295-a214-78f751a1a353.mov


