### PR TITLE
Jr fc refactor handle checkbox

### DIFF
--- a/src/components/AddItemForm.js
+++ b/src/components/AddItemForm.js
@@ -57,7 +57,7 @@ function AddItemForm() {
       purchaseInterval: purchaseInterval,
       userToken: userToken,
       lastPurchased: lastPurchased,
-      nextPurchase: null,
+      daysUntilNextPurchase: null,
       numberOfPurchases: 0,
     });
   };

--- a/src/components/AddItemForm.js
+++ b/src/components/AddItemForm.js
@@ -59,6 +59,9 @@ function AddItemForm() {
       lastPurchased: lastPurchased,
       daysUntilNextPurchase: null,
       numberOfPurchases: 0,
+      backupLastPurchased: lastPurchased,
+      backupDaysUntilNextPurchase: null,
+      backupNumberOfPurchases: 0,
     });
   };
 

--- a/src/components/AddItemForm.js
+++ b/src/components/AddItemForm.js
@@ -57,6 +57,8 @@ function AddItemForm() {
       purchaseInterval: purchaseInterval,
       userToken: userToken,
       lastPurchased: lastPurchased,
+      nextPurchase: null,
+      numberOfPurchases: 0,
     });
   };
 

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -7,8 +7,7 @@ import './Item.css';
 function Item({ item, userToken }) {
   const [checked, setChecked] = useState(false);
   const [daysSincePurchased, setDaysSincePurchased] = useState(0);
-  const [itemBackup, setItemBackup] = useState(item);
-  console.log('itemBackup', itemBackup);
+  const [itemBackup] = useState(item);
 
   useEffect(() => {
     if (item.lastPurchased) {
@@ -21,11 +20,12 @@ function Item({ item, userToken }) {
   }, [item]);
 
   useEffect(() => {
-    if (daysSincePurchased > 1 || daysSincePurchased === 0) {
-      setChecked(false);
-    } else if (daysSincePurchased < 1) {
+    if (daysSincePurchased < 1 && daysSincePurchased !== 0) {
       setChecked(true);
+      return;
     }
+
+    setChecked(false);
   }, [daysSincePurchased, checked]);
 
   const handleCheckboxChange = () => {
@@ -35,7 +35,6 @@ function Item({ item, userToken }) {
   const updateLastPurchased = async (event) => {
     const docRef = doc(db, 'users', `${userToken}`, 'list', item.id);
     if (event.target.checked) {
-      // setItemBackup(item)
       updateDoc(docRef, {
         lastPurchased: serverTimestamp(),
         numberOfPurchases: item.numberOfPurchases + 1,

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { updateDoc, serverTimestamp, doc } from 'firebase/firestore';
+import { updateDoc, serverTimestamp, doc, getDoc } from 'firebase/firestore';
 import { db } from '../lib/firebase';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import './Item.css';
 
 function Item({ item, userToken }) {
@@ -32,12 +33,19 @@ function Item({ item, userToken }) {
   const updateLastPurchased = async (event) => {
     const docRef = doc(db, 'users', `${userToken}`, 'list', item.id);
     if (event.target.checked) {
-      await updateDoc(docRef, {
+      updateDoc(docRef, {
         lastPurchased: serverTimestamp(),
+        numberOfPurchases: item.numberOfPurchases + 1,
+        nextPurchase: calculateEstimate(
+          item.purchaseInterval,
+          daysSincePurchased,
+          item.numberOfPurchases,
+        ),
       });
     } else {
-      await updateDoc(docRef, {
+      updateDoc(docRef, {
         lastPurchased: null,
+        numberOfPurchases: item.numberOfPurchases - 1,
       });
       setDaysSincePurchased(null);
     }


### PR DESCRIPTION
## Description

This PR is a refactor of the code to calculate and save `daysUntilNextPurchase` and the code to handle the check and uncheck of the purchase checkbox.

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :hammer: Refactoring       |

## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
- ```git checkout jr-fc-refactor-handle-checkbox```
- ```npm start```
- Create a new list and add a few items
- Open Firestore and open items you added
- when you click the purchased checkbox you will now see the daysUntilNextPurchase recorded with the calculateEstimate results
- You can uncheck if you change your mind and see the values are reverted back to the previous state as a limited version control
