### PR TITLE
Sort list by next purchase date

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -43,8 +43,6 @@ function App() {
     setUserToken(window.localStorage.getItem('userToken'));
   }
 
-  console.log('userToken:', userToken);
-
   return (
     <div className="App">
       <Router>

--- a/src/components/Helper.js
+++ b/src/components/Helper.js
@@ -17,3 +17,8 @@ export const calculateDaysSincePurchased = (lastPurchased) => {
     return differenceInSeconds / 86400;
   }
 };
+
+export const isActive = (item, daysSincePurchased) =>
+  item !== null &&
+  (daysSincePurchased * 2 <= item.daysUntilNextPurchase ||
+    item.numberOfPurchases > 1);

--- a/src/components/Helper.js
+++ b/src/components/Helper.js
@@ -7,3 +7,13 @@ export const normalizeValue = (value) => {
     .replace(emojiRegex, '');
   return normalizedValue;
 };
+
+export const calculateDaysSincePurchased = (lastPurchased) => {
+  if (lastPurchased) {
+    const lastPurchasedSeconds = lastPurchased.seconds;
+    const dateNowSeconds = Date.now() / 1000;
+    const differenceInSeconds = dateNowSeconds - lastPurchasedSeconds;
+
+    return differenceInSeconds / 86400;
+  }
+};

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -4,7 +4,7 @@ import { db } from '../lib/firebase';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import './Item.css';
 import DeleteItemButton from './DeleteItemButton';
-import { calculateDaysSincePurchased } from './Helper';
+import { calculateDaysSincePurchased, isActive } from './Helper';
 
 function Item({ item, userToken, focusOnInput }) {
   const [checked, setChecked] = useState(false);
@@ -49,6 +49,7 @@ function Item({ item, userToken, focusOnInput }) {
           daysSincePurchased,
           item.numberOfPurchases,
         ),
+        10,
       ),
     });
   };
@@ -62,17 +63,11 @@ function Item({ item, userToken, focusOnInput }) {
     });
   };
 
-  // move isActive to Helper.js, import to this file and ItemList.js
-  const isActive = (item) =>
-    item !== null &&
-    (item.daysSincePurchased * 2 <= item.daysUntilNextPurchase ||
-      item.numberOfPurchases > 1);
-
   let checkboxStyle = {};
   let nameAriaLabel = '';
 
   switch (true) {
-    case !isActive(item):
+    case !isActive(item, daysSincePurchased):
       checkboxStyle = { backgroundColor: 'lightgray' };
       nameAriaLabel = `${item.itemName} is inactive.`;
       break;
@@ -92,11 +87,6 @@ function Item({ item, userToken, focusOnInput }) {
       checkboxStyle = { backgroundColor: 'lightgray' };
       nameAriaLabel = `${item.itemName} inactive.`;
   }
-
-  console.log('itemName', item.itemName);
-  console.log('daysSincePurchased', daysSincePurchased);
-  console.log('numberOfPurchases', item.numberOfPurchases);
-  console.log('daysUntilNextPurchase', item.daysUntilNextPurchase);
 
   return (
     <li aria-label={nameAriaLabel} className="item" style={checkboxStyle}>

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -46,13 +46,17 @@ function Item({ item, userToken, focusOnInput }) {
       backupNumberOfPurchases: item.numberOfPurchases,
       lastPurchased: serverTimestamp(),
       numberOfPurchases: item.numberOfPurchases + 1,
-      daysUntilNextPurchase: calculateEstimate(
-        item.purchaseInterval,
-        daysSincePurchased,
-        item.numberOfPurchases,
+      daysUntilNextPurchase: parseInt(
+        calculateEstimate(
+          item.purchaseInterval,
+          daysSincePurchased,
+          item.numberOfPurchases,
+        ),
       ),
     });
   };
+
+  // const daysSincePurchasedWhole = daysSincePurchased.toFixed(0)
 
   const handleUnCheck = async () => {
     const docRef = doc(db, 'users', `${userToken}`, 'list', item.id);
@@ -64,7 +68,16 @@ function Item({ item, userToken, focusOnInput }) {
   };
 
   return (
-    <li className="item">
+    <li
+      className="item"
+      style={
+        item.daysUntilNextPurchase >= 2 && item.daysUntilNextPurchase <= 7
+          ? { backgroundColor: 'lightgreen' } // 2 thru 7 = lightgreen
+          : item.daysUntilNextPurchase >= 8 && item.daysUntilNextPurchase <= 30
+          ? { backgroundColor: 'lightblue' } // 8 thru 30 = lightblue
+          : { backgroundColor: 'lightgray' } // anything else = lightgray
+      }
+    >
       <form>
         <label htmlFor={`itemPurchased-${item.id}`}>Purchased</label>
         <input
@@ -76,6 +89,10 @@ function Item({ item, userToken, focusOnInput }) {
         />
       </form>
       <p className="item-name">{item.itemName}</p>
+      <p className="item-name">
+        daysUntilNextPurchase {item.daysUntilNextPurchase} day(s)
+      </p>
+      <p className="item-name">daysSincePurchased: {daysSincePurchased}</p>
       <DeleteItemButton
         item={item.id}
         userToken={userToken}

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -4,6 +4,7 @@ import { db } from '../lib/firebase';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import './Item.css';
 import DeleteItemButton from './DeleteItemButton';
+import { calculateDaysSincePurchased } from './Helper';
 
 function Item({ item, userToken, focusOnInput }) {
   const [checked, setChecked] = useState(false);
@@ -11,11 +12,7 @@ function Item({ item, userToken, focusOnInput }) {
 
   useEffect(() => {
     if (item.lastPurchased) {
-      const lastPurchasedSeconds = item.lastPurchased.seconds;
-      const dateNowSeconds = Date.now() / 1000;
-      const differenceInSeconds = dateNowSeconds - lastPurchasedSeconds;
-
-      setDaysSincePurchased(differenceInSeconds / 86400);
+      setDaysSincePurchased(calculateDaysSincePurchased(item.lastPurchased));
     }
   }, [item]);
 

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -53,8 +53,6 @@ function Item({ item, userToken, focusOnInput }) {
     });
   };
 
-  // const daysSincePurchasedWhole = daysSincePurchased.toFixed(0)
-
   const handleUnCheck = async () => {
     const docRef = doc(db, 'users', `${userToken}`, 'list', item.id);
     updateDoc(docRef, {
@@ -96,10 +94,6 @@ function Item({ item, userToken, focusOnInput }) {
         />
       </form>
       <p className="item-name">{item.itemName}</p>
-      <p className="item-name">
-        daysUntilNextPurchase {item.daysUntilNextPurchase} day(s)
-      </p>
-      <p className="item-name">daysSincePurchased: {daysSincePurchased}</p>
       <DeleteItemButton
         item={item.id}
         userToken={userToken}

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -62,26 +62,44 @@ function Item({ item, userToken, focusOnInput }) {
     });
   };
 
-  const checkboxStyle =
-    item.daysUntilNextPurchase >= 2 && item.daysUntilNextPurchase <= 7
-      ? { backgroundColor: 'lightgreen' } // 2 thru 7 = lightgreen
-      : item.daysUntilNextPurchase >= 8 && item.daysUntilNextPurchase <= 30
-      ? { backgroundColor: 'lightblue' } // 8 thru 30 = lightblue
-      : item.daysUntilNextPurchase > 30
-      ? { backgroundColor: 'lightyellow' } // 31+ = lightyellow
-      : { backgroundColor: 'lightgray' }; // anything else = lightgray
+  // move isActive to Helper.js, import to this file and ItemList.js
+  const isActive = (item) =>
+    item !== null &&
+    (item.daysSincePurchased * 2 <= item.daysUntilNextPurchase ||
+      item.numberOfPurchases > 1);
 
-  const checkboxAriaLabel =
-    item.daysUntilNextPurchase >= 2 && item.daysUntilNextPurchase <= 7
-      ? `${item.itemName} state: buy soon. Marked as purchased.` // 2 thru 7 = lightgreen
-      : item.daysUntilNextPurchase >= 8 && item.daysUntilNextPurchase <= 30
-      ? `${item.itemName} state: buy kind of soon. Marked as purchased.` // 8 thru 30 = lightblue
-      : item.daysUntilNextPurchase > 30
-      ? `${item.itemName} state: buy not soon. Marked as purchased.` // 31+ = lightyellow
-      : `${item.itemName} inactive. Marked as purchased.`; // anything else = lightgray
+  let checkboxStyle = {};
+  let nameAriaLabel = '';
+
+  switch (true) {
+    case !isActive(item):
+      checkboxStyle = { backgroundColor: 'lightgray' };
+      nameAriaLabel = `${item.itemName} is inactive.`;
+      break;
+    case item.daysUntilNextPurchase >= 2 && item.daysUntilNextPurchase <= 7:
+      checkboxStyle = { backgroundColor: 'lightgreen' };
+      nameAriaLabel = `Buy ${item.itemName} soon`;
+      break;
+    case item.daysUntilNextPurchase >= 8 && item.daysUntilNextPurchase <= 30:
+      checkboxStyle = { backgroundColor: 'lightblue' };
+      nameAriaLabel = `Buy ${item.itemName} kind of soon.`;
+      break;
+    case item.daysUntilNextPurchase > 30:
+      checkboxStyle = { backgroundColor: 'lightyellow' };
+      nameAriaLabel = `Buy ${item.itemName} not soon.`;
+      break;
+    default:
+      checkboxStyle = { backgroundColor: 'lightgray' };
+      nameAriaLabel = `${item.itemName} inactive.`;
+  }
+
+  console.log('itemName', item.itemName);
+  console.log('daysSincePurchased', daysSincePurchased);
+  console.log('numberOfPurchases', item.numberOfPurchases);
+  console.log('daysUntilNextPurchase', item.daysUntilNextPurchase);
 
   return (
-    <li className="item" style={checkboxStyle}>
+    <li aria-label={nameAriaLabel} className="item" style={checkboxStyle}>
       <form>
         <label htmlFor={`itemPurchased-${item.id}`}>Purchased</label>
         <input
@@ -90,7 +108,6 @@ function Item({ item, userToken, focusOnInput }) {
           checked={checked}
           name="itemPurchased"
           onChange={handleCheckboxChange}
-          aria-label={checkboxAriaLabel}
         />
       </form>
       <p className="item-name">{item.itemName}</p>

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -64,17 +64,26 @@ function Item({ item, userToken, focusOnInput }) {
     });
   };
 
+  const checkboxStyle =
+    item.daysUntilNextPurchase >= 2 && item.daysUntilNextPurchase <= 7
+      ? { backgroundColor: 'lightgreen' } // 2 thru 7 = lightgreen
+      : item.daysUntilNextPurchase >= 8 && item.daysUntilNextPurchase <= 30
+      ? { backgroundColor: 'lightblue' } // 8 thru 30 = lightblue
+      : item.daysUntilNextPurchase > 30
+      ? { backgroundColor: 'lightyellow' } // 31+ = lightyellow
+      : { backgroundColor: 'lightgray' }; // anything else = lightgray
+
+  const checkboxAriaLabel =
+    item.daysUntilNextPurchase >= 2 && item.daysUntilNextPurchase <= 7
+      ? `${item.itemName} state: buy soon. Marked as purchased.` // 2 thru 7 = lightgreen
+      : item.daysUntilNextPurchase >= 8 && item.daysUntilNextPurchase <= 30
+      ? `${item.itemName} state: buy kind of soon. Marked as purchased.` // 8 thru 30 = lightblue
+      : item.daysUntilNextPurchase > 30
+      ? `${item.itemName} state: buy not soon. Marked as purchased.` // 31+ = lightyellow
+      : `${item.itemName} inactive. Marked as purchased.`; // anything else = lightgray
+
   return (
-    <li
-      className="item"
-      style={
-        item.daysUntilNextPurchase >= 2 && item.daysUntilNextPurchase <= 7
-          ? { backgroundColor: 'lightgreen' } // 2 thru 7 = lightgreen
-          : item.daysUntilNextPurchase >= 8 && item.daysUntilNextPurchase <= 30
-          ? { backgroundColor: 'lightblue' } // 8 thru 30 = lightblue
-          : { backgroundColor: 'lightgray' } // anything else = lightgray
-      }
-    >
+    <li className="item" style={checkboxStyle}>
       <form>
         <label htmlFor={`itemPurchased-${item.id}`}>Purchased</label>
         <input
@@ -83,6 +92,7 @@ function Item({ item, userToken, focusOnInput }) {
           checked={checked}
           name="itemPurchased"
           onChange={handleCheckboxChange}
+          aria-label={checkboxAriaLabel}
         />
       </form>
       <p className="item-name">{item.itemName}</p>

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -3,7 +3,7 @@ import { collection, onSnapshot, query, orderBy } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { NavLink } from 'react-router-dom';
 import SearchList from './SearchList';
-import { calculateDaysSincePurchased } from './Helper.js';
+import { calculateDaysSincePurchased, isActive } from './Helper.js';
 
 function ItemList({ userToken }) {
   const [listItems, setListItems] = useState([]);
@@ -21,21 +21,17 @@ function ItemList({ userToken }) {
     return unsubscribe;
   }, [userToken]);
 
-  const isActive = (item) =>
-    item !== null &&
-    (calculateDaysSincePurchased(item.lastPurchased) * 2 <=
-      item.daysUntilNextPurchase ||
-      item.numberOfPurchases > 1);
-
   listItems.sort((itemA, itemB) => {
     if (
-      (isActive(itemA) && isActive(itemB)) ||
-      (!isActive(itemA) && !isActive(itemB))
+      (isActive(itemA, calculateDaysSincePurchased(itemA.lastPurchased)) &&
+        isActive(itemB, calculateDaysSincePurchased(itemB.lastPurchased))) ||
+      (!isActive(itemA, calculateDaysSincePurchased(itemA.lastPurchased)) &&
+        !isActive(itemB, calculateDaysSincePurchased(itemB.lastPurchased)))
     ) {
       return itemA.daysUntilNextPurchase - itemB.daysUntilNextPurchase;
     }
 
-    if (isActive(itemA)) {
+    if (isActive(itemA, calculateDaysSincePurchased(itemA.lastPurchased))) {
       return -1;
     }
     return 1;

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -3,6 +3,7 @@ import { collection, onSnapshot, query, orderBy } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { NavLink } from 'react-router-dom';
 import SearchList from './SearchList';
+import { calculateDaysSincePurchased } from './Helper.js';
 
 function ItemList({ userToken }) {
   const [listItems, setListItems] = useState([]);
@@ -22,7 +23,8 @@ function ItemList({ userToken }) {
 
   const isActive = (item) =>
     item !== null &&
-    (item.daysSincePurchased * 2 <= item.daysUntilNextPurchase ||
+    (calculateDaysSincePurchased(item.lastPurchased) * 2 <=
+      item.daysUntilNextPurchase ||
       item.numberOfPurchases > 1);
 
   listItems.sort((itemA, itemB) => {

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -3,7 +3,6 @@ import { collection, onSnapshot, query, orderBy } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { NavLink } from 'react-router-dom';
 import SearchList from './SearchList';
-import { calculateDaysSincePurchased } from './Helper';
 
 function ItemList({ userToken }) {
   const [listItems, setListItems] = useState([]);
@@ -22,11 +21,11 @@ function ItemList({ userToken }) {
   }, [userToken]);
 
   /*
-         | itemA | itemB |
-  active | T     | T     | -> compare daysUntilNextPurchase
-         | T     | F     | -> return 1, itemA goes before itemB
-         | F     | T     | -> return -1, itemB goes before itemA
-         | F     | F     | -> compare daysUntilNextPurchase
+           | itemA | itemB |
+  isActive | T     | T     | -> compare daysUntilNextPurchase
+           | T     | F     | -> return 1, itemA goes before itemB
+           | F     | T     | -> return -1, itemB goes before itemA
+           | F     | F     | -> compare daysUntilNextPurchase
   */
 
   const isActive = (item) =>
@@ -39,7 +38,7 @@ function ItemList({ userToken }) {
       (isActive(itemA) && isActive(itemB)) ||
       (!isActive(itemA) && !isActive(itemB))
     ) {
-      return itemB.daysUntilNextPurchase - itemA.daysUntilNextPurchase;
+      return itemA.daysUntilNextPurchase - itemB.daysUntilNextPurchase;
     }
 
     if (isActive(itemA)) {

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -20,6 +20,11 @@ function ItemList({ userToken }) {
     return unsubscribe;
   }, [userToken]);
 
+  // sort the alphabetical list in place, and return items with equal values for daysUntilNextPurchase in alphabetical order
+  listItems.sort(
+    (itemA, itemB) => itemA.daysUntilNextPurchase - itemB.daysUntilNextPurchase,
+  );
+
   return (
     <div>
       <div>

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { collection, onSnapshot, query } from 'firebase/firestore';
+import { collection, onSnapshot, query, orderBy } from 'firebase/firestore';
 import { db } from '../lib/firebase';
 import { NavLink } from 'react-router-dom';
 import SearchList from './SearchList';
@@ -8,7 +8,10 @@ function ItemList({ userToken }) {
   const [listItems, setListItems] = useState([]);
 
   useEffect(() => {
-    const q = query(collection(db, 'users', `${userToken}`, 'list'));
+    const q = query(
+      collection(db, 'users', `${userToken}`, 'list'),
+      orderBy('itemNameNormalize', 'asc'),
+    );
 
     const unsubscribe = onSnapshot(q, (snapshot) =>
       setListItems(snapshot.docs.map((doc) => ({ ...doc.data(), id: doc.id }))),

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -20,14 +20,6 @@ function ItemList({ userToken }) {
     return unsubscribe;
   }, [userToken]);
 
-  /*
-           | itemA | itemB |
-  isActive | T     | T     | -> compare daysUntilNextPurchase
-           | T     | F     | -> return 1, itemA goes before itemB
-           | F     | T     | -> return -1, itemB goes before itemA
-           | F     | F     | -> compare daysUntilNextPurchase
-  */
-
   const isActive = (item) =>
     item !== null &&
     (item.daysSincePurchased * 2 <= item.daysUntilNextPurchase ||

--- a/src/components/TokenForm.js
+++ b/src/components/TokenForm.js
@@ -11,7 +11,6 @@ export default function TokenForm({ grabExistingTokenAndSaveToLocalStorage }) {
     const querySnapshot = await getDocs(q);
 
     if (querySnapshot.docs.length) {
-      console.log('querySnapshot', querySnapshot.docs);
       grabExistingTokenAndSaveToLocalStorage(e.target.sharedToken.value);
     } else {
       alert('Error: This token does not exist');


### PR DESCRIPTION
## Description

This code now adds logic to check if an item is active or inactive based on if the time that has elapsed since its last purchase is twice (or more) what was estimated the last time it was purchased.

The list is now sorted by the estimated number of days until the next purchase as well as inactive items being placed on the bottom of the list. Each section (Soon, Kind of soon, Not soon, Inactive) is visually distinct as well.

## Related Issue

Closes #12 

## Acceptance Criteria

- [ ] Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
- [ ] Items should be sorted by the estimated number of days until the next purchase
- [ ] Items with the same number of estimated days until next purchase should be sorted alphabetically
- [ ] Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :sparkles: New feature     |

## Updates

### Before

![](https://cdn.zappy.app/a10eb1e8a98a6e8e4ca51f5c088d1321.png)

### After

![](https://cdn.zappy.app/cff849e7551e6c255c2abd4e3a086711.png)


## Testing Steps / QA Criteria

1.  ```git checkout mh-sk-fc-jr-sort-list-by-next-purchase-date```
2. ```npm start```
3.  Open Firestore database 
4. Create list and add several items
5. check off the items 
6. In Firestore, change the lastPurchased, daysUntilNextPurchase, and numberOfPurchases to show the changes in sorting and testing different scenarios
7. Coloring and order should match 
